### PR TITLE
sentry: attach SentryHandler to Flask app log handlers

### DIFF
--- a/invenio_logging/sentry.py
+++ b/invenio_logging/sentry.py
@@ -80,6 +80,8 @@ class InvenioLoggingSentry(InvenioLoggingBase):
             level=level
         )
 
+        app.logger.addHandler(SentryHandler(sentry.client, level))
+
         # Capture warnings from warnings module
         if app.config['LOGGING_SENTRY_PYWARNINGS']:
             self.capture_pywarnings(

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ extras_require = {
     ],
     'tests': tests_require,
     'sentry': [
-        'raven[flask]>=5.0.0',
+        'raven[flask]>=5.0.0,<5.5',
         'flask-celeryext>=0.2.2',
     ]
 }

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -74,6 +74,19 @@ def test_stream_handler_in_debug(pywarnlogger):
     assert logging.StreamHandler in [x.__class__ for x in logger.handlers]
 
 
+def test_sentry_handler_attached_to_app_logger():
+    from invenio_logging.sentry import InvenioLoggingSentry
+    from raven.handlers.logging import SentryHandler
+    app = Flask('testapp')
+    app.config['SENTRY_DSN'] = 'http://user:pw@localhost/0'
+    InvenioLoggingSentry(app)
+    assert any(
+        [
+            isinstance(logger, SentryHandler) for logger in app.logger.handlers
+        ]
+    )
+
+
 def test_pywarnings(pywarnlogger):
     """Test celery."""
     from invenio_logging.sentry import InvenioLoggingSentry


### PR DESCRIPTION
* Errors will arrive to Sentry when using, for example, app.logger.error
  or app.logger.exception.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>