### PR TITLE
tests: doctext execution simplification

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,12 +27,6 @@
 from __future__ import print_function
 
 import os
-import sys
-
-import sphinx.environment
-
-# Plug example application into module path
-sys.path.append('examples')
 
 # -- General configuration ------------------------------------------------
 
@@ -80,7 +74,9 @@ author = u'CERN'
 
 # Get the version string. Cannot be done with import!
 g = {}
-with open(os.path.join('..', 'invenio_logging', 'version.py'), 'rt') as fp:
+with open(os.path.join(os.path.dirname(__file__), '..',
+                       'invenio_logging', 'version.py'),
+          'rt') as fp:
     exec(fp.read(), g)
     version = g['__version__']
 

--- a/docs/examplesapp.rst
+++ b/docs/examplesapp.rst
@@ -24,4 +24,6 @@
 Example application
 ===================
 
-.. automodule:: app
+.. include:: ../examples/app.py
+   :start-after: SPHINX-START
+   :end-before: SPHINX-END

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
--e .[docs,tests]
+-e .[docs,tests,sentry]

--- a/examples/app.py
+++ b/examples/app.py
@@ -25,6 +25,8 @@
 
 """Minimal Flask application example.
 
+SPHINX-START
+
 First install Invenio-Logging, setup the application and load
 fixture data by running:
 
@@ -56,6 +58,8 @@ To reset the example application run:
 .. code-block:: console
 
     $ ./app-teardown.sh
+
+SPHINX-END
 """
 
 from __future__ import absolute_import, print_function

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,4 +23,5 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --pep8 --ignore=docs --cov=invenio_logging --cov-report=term-missing
+pep8ignore = docs/conf.py ALL
+ddopts = --pep8 --doctest-glob="*.rst" --doctest-modules --cov=invenio_logging --cov-report=term-missing docs tests invenio_logging

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -26,5 +26,4 @@ pydocstyle invenio_logging && \
 isort -rc -c -df **/*.py && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
-python setup.py test && \
-sphinx-build -qnNW -b doctest docs docs/_build/doctest
+python setup.py test


### PR DESCRIPTION
* doctests are now executed with pytest instead of sphinx. (closes #29, closes #27)