### PR TITLE
Add missing config and release v1.1.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,17 @@
 ..
     This file is part of Invenio.
-    Copyright (C) 2015-2018 CERN.
+    Copyright (C) 2015-2019 CERN.
 
     Invenio is free software; you can redistribute it and/or modify it
     under the terms of the MIT License; see LICENSE file for more details.
 
 Changes
 =======
+
+Version 1.1.1 (released 2019-06-19)
+
+- Fixed incorrect warnings logging by Sentry.
+- Fixed unused config variables for Sentry.
 
 Version 1.1.0 (released 2018-12-14)
 

--- a/invenio_logging/config.py
+++ b/invenio_logging/config.py
@@ -112,5 +112,9 @@ SENTRY_PROCESSORS = (
 )
 """Default Sentry event processors."""
 
-SENTRY_TRANSPORT = 'raven.transport.threaded.ThreadedHTTPTransport'
-"""Default Sentry transport."""
+SENTRY_TRANSPORT = 'raven.transport.http.HTTPTransport'
+"""Default Sentry transport.
+
+Explicitly set due to Celery incompatibility with threaded transport
+(see note above).
+"""

--- a/invenio_logging/sentry.py
+++ b/invenio_logging/sentry.py
@@ -50,7 +50,7 @@ class InvenioLoggingSentry(InvenioLoggingBase):
     def init_config(self, app):
         """Initialize configuration."""
         for k in dir(config):
-            if k.startswith('LOGGING_SENTRY') or k.startswith('SENTRY_DSN'):
+            if k.startswith('LOGGING_SENTRY') or k.startswith('SENTRY_'):
                 app.config.setdefault(k, getattr(config, k))
 
     def install_handler(self, app):

--- a/invenio_logging/version.py
+++ b/invenio_logging/version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2015-2019 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'


### PR DESCRIPTION
Currently, there are variables in ```config.py``` that are not registered during the initialization of the module and as a result they never get picked up from Sentry.
This means that with merging this PR, the variables  ```SENTRY_TRANSPORT``` that was present but not used before, now might override any default that is currently being used. 
Also, the variable: ```SENTRY_PROCESSORS``` which includes the ```request_id```processor will be also included in the Sentry configuration.