### PR TITLE
fix: upgrade sentry-sdk from v1 to v2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,13 +36,12 @@ tests =
     flask-login>=0.6.1
     httpretty>=0.8.14
     mock>=1.3.0
-    pytest-invenio>=3.0.0,<4.0.0
+    pytest-invenio>=4.0.0,<5.0.0
     iniconfig>=1.1.1
     sphinx>=4.5
-    # Sentry-SDK v2.x has breaking changes (see https://github.com/inveniosoftware/invenio-logging/issues/73)
-    sentry-sdk[flask]>=1.0.0,<2.0.0
+    sentry-sdk[flask]>=2.0.0,<3.0.0
 sentry =
-    sentry-sdk[flask]>=1.0.0,<2.0.0
+    sentry-sdk[flask]>=2.0.0,<3.0.0
 
 [options.entry_points]
 invenio_base.apps =

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,6 +10,9 @@
 """Sentry logging tests."""
 
 from __future__ import absolute_import, print_function
+
+import time
+from unittest.mock import patch
 
 from flask import Flask
 from sentry_sdk.hub import Hub
@@ -34,3 +38,29 @@ def test_init():
         assert Hub.current.get_integration(CeleryIntegration)
     else:
         assert Hub.current.get_integration(FlaskIntegration)
+
+
+def test_sentry_failure():
+    """Test that sentry works and logs a failure."""
+    import sentry_sdk
+
+    from invenio_logging.sentry import InvenioLoggingSentry
+
+    app = Flask("testapp")
+    app.config["SENTRY_DSN"] = "http://a-secret-hash@127.0.0.1:8000/1"
+    InvenioLoggingSentry(app)
+
+    sentry_transport = sentry_sdk.get_global_scope().client.transport
+
+    with patch.object(sentry_transport, "_send_request") as mock_send_request:
+        try:
+            1 / 0
+        except:
+            app.logger.exception("Division by zero")
+
+        # wait a bit for sentry-sdk to send the message
+        time.sleep(2)
+
+        mock_send_request.assert_called()
+
+    assert sentry_sdk.last_event_id() is not None

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -14,16 +14,17 @@ from __future__ import absolute_import, print_function
 import time
 from unittest.mock import patch
 
+import sentry_sdk
 from flask import Flask
 from sentry_sdk.hub import Hub
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.flask import FlaskIntegration
 
+from invenio_logging.sentry import InvenioLoggingSentry
+
 
 def test_init():
     """Test initialization."""
-    from invenio_logging.sentry import InvenioLoggingSentry
-
     app = Flask("testapp")
     InvenioLoggingSentry(app)
     assert "invenio-logging-sentry" not in app.extensions
@@ -42,9 +43,6 @@ def test_init():
 
 def test_sentry_failure():
     """Test that sentry works and logs a failure."""
-    import sentry_sdk
-
-    from invenio_logging.sentry import InvenioLoggingSentry
 
     app = Flask("testapp")
     app.config["SENTRY_DSN"] = "http://a-secret-hash@127.0.0.1:8000/1"

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -16,7 +16,6 @@ from unittest.mock import patch
 
 import sentry_sdk
 from flask import Flask
-from sentry_sdk.hub import Hub
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.flask import FlaskIntegration
 
@@ -34,11 +33,14 @@ def test_init():
     InvenioLoggingSentry(app)
     assert "invenio-logging-sentry" in app.extensions
 
-    assert Hub.current and Hub.client
+    sentry_global_scope = sentry_sdk.get_global_scope()
+
+    assert sentry_global_scope.client is not None
+
     if app.config["LOGGING_SENTRY_CELERY"]:
-        assert Hub.current.get_integration(CeleryIntegration)
+        assert sentry_global_scope.client.get_integration(CeleryIntegration)
     else:
-        assert Hub.current.get_integration(FlaskIntegration)
+        assert sentry_global_scope.client.get_integration(FlaskIntegration)
 
 
 def test_sentry_failure():


### PR DESCRIPTION
### Description

invenio-logging uses old version of sentry-sdk that seems to be incompatible with current python 3.14 (unable to send stack traces to glitchtip server). The reason it was not bumped previously has been described in https://github.com/inveniosoftware/invenio-logging/issues/73, this PR fixes that.

The `last_event_id` was at first removed from sentry, later in 2.2 added back so we can use it - see https://github.com/getsentry/sentry-python/issues/3049

In this PR:

* sentry-sdk was bumped from v1 to v2
* pytest-invenio was bumped as well
* added test to check that message is sent to sentry and last_event_id is generated


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
