### PR TITLE
sentry: drop explicitly flagged log records

### DIFF
--- a/invenio_logging/sentry.py
+++ b/invenio_logging/sentry.py
@@ -112,6 +112,10 @@ class InvenioLoggingSentry(InvenioLoggingBase):
 
     def add_request_id_sentry_python(self, event, hint):
         """Add the request id as a tag."""
+        log_record = hint.get("log_record")
+        if log_record and getattr(log_record, "skip_sentry", False):
+            return None
+
         if g and hasattr(g, "request_id"):
             tags = event.get("tags") or []
             tags.append(["request_id", g.request_id])


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description
Closes https://github.com/CERNDocumentServer/cds-rdm/issues/813
Related pr : https://github.com/inveniosoftware/invenio-vocabularies/pull/551

This adds a small check in the Sentry hook to skip sending log records that were explicitly marked with skip_sentry=True. The idea is to allow some expected logs to remain visible in the application without creating noise in Sentry, while leaving the behavior for all other errors unchanged.




### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
