### PR TITLE
Remove Flask's default logging handler on console logging handler registration

### DIFF
--- a/invenio_logging/console.py
+++ b/invenio_logging/console.py
@@ -16,6 +16,8 @@ from flask.logging import default_handler
 from . import config
 from .ext import InvenioLoggingBase
 
+handler = logging.StreamHandler()
+
 
 class InvenioLoggingConsole(InvenioLoggingBase):
     """Invenio-Logging extension for console."""
@@ -41,8 +43,8 @@ class InvenioLoggingConsole(InvenioLoggingBase):
 
     def install_handler(self, app):
         """Install logging handler."""
-        # Configure python logging
-        handler = logging.StreamHandler()
+        if handler in app.logger.handlers:
+            return
 
         if app.config["LOGGING_CONSOLE_PYWARNINGS"]:
             self.capture_pywarnings(handler)

--- a/invenio_logging/console.py
+++ b/invenio_logging/console.py
@@ -11,6 +11,8 @@ from __future__ import absolute_import, print_function
 
 import logging
 
+from flask.logging import default_handler
+
 from . import config
 from .ext import InvenioLoggingBase
 
@@ -50,3 +52,6 @@ class InvenioLoggingConsole(InvenioLoggingBase):
 
         # Add the handler to the app logger
         app.logger.addHandler(handler)
+
+        # Remove the (likely unconfigured) Flask default handler
+        app.logger.removeHandler(default_handler)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import shutil
 import tempfile
 
 import pytest
-from mock import Mock, patch
+from mock import patch
 
 
 @pytest.yield_fixture()

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -50,7 +50,7 @@ def test_sentry_failure():
     with patch.object(sentry_transport, "_send_request") as mock_send_request:
         try:
             1 / 0
-        except:
+        except ZeroDivisionError:
             app.logger.exception("Division by zero")
 
         # wait a bit for sentry-sdk to send the message


### PR DESCRIPTION
From the [Flask logging documentation](https://flask.palletsprojects.com/en/stable/logging/):
> If you do not configure logging yourself, Flask will add a [StreamHandler](https://docs.python.org/3/library/logging.handlers.html#logging.StreamHandler) to [app.logger](https://flask.palletsprojects.com/en/stable/api/#flask.Flask.logger) automatically.

It seems like that this logic kicks in before the `Invenio-Logging` package does (or at least, before the `InvenioLoggingConsole` gets to register its `StreamHandler`), and we end up with multiple logging handlers that do the (almost) same thing.

Since the `default_handler` doesn't get properly initialized with a decent log level anywhere in Invenio yet, it basically logs any `DEBUG` statement ([since the general `app.logger` is set to that level](https://github.com/inveniosoftware/invenio-logging/blob/v4.2.0/invenio_logging/ext.py#L29-L31)).
This surprisingly has a relevant performance impact on some endpoints like the [community logo API endpoint](https://github.com/inveniosoftware/invenio-communities/blob/v29.0.0/invenio_communities/communities/resources/resource.py#L108) if something goes wrong, because [`create_error_handler()` logs debug statements](https://github.com/inveniosoftware/flask-resources/blob/v1.3.0/flask_resources/errors.py#L38-L40).

This PR removes the `default_handler` from Flask when a console handler is registered.