### PR TITLE
Sentry legacy store transport and tags fix

### DIFF
--- a/invenio_logging/sentry.py
+++ b/invenio_logging/sentry.py
@@ -5,7 +5,10 @@
 
 from __future__ import absolute_import, print_function
 
+import gzip
+import io
 import logging
+from types import SimpleNamespace
 
 from flask import g
 
@@ -14,8 +17,10 @@ from .ext import InvenioLoggingBase
 
 try:
     import sentry_sdk
+    from sentry_sdk.transport import HttpTransport
 except ImportError:
     sentry_sdk = None
+    HttpTransport = object
 
 
 class InvenioLoggingSentry(InvenioLoggingBase):
@@ -120,3 +125,44 @@ class InvenioLoggingSentry(InvenioLoggingBase):
         if event_id is not None:
             g.sentry_event_id = event_id
         return event
+
+
+class LegacyStoreTransport(HttpTransport):
+    """Route Sentry error events to the legacy ``/store/`` endpoint.
+
+    sentry-sdk 2.x sends only envelopes, which pre-envelope Sentry servers
+    (e.g. Sentry 9.x) reject, so every event is silently dropped. This transport
+    posts events to the ``/store/`` endpoint those servers understand.
+
+    Enable it in ``invenio.cfg``::
+
+        from invenio_logging.sentry import LegacyStoreTransport
+
+        LOGGING_SENTRY_INIT_KWARGS = {"transport": LegacyStoreTransport}
+    """
+
+    # sentry-sdk 2.x's EndpointType enum dropped "store", but Auth.get_api_url()
+    # still builds the URL from <endpoint>.value, so this marker resolves to the
+    # legacy /store/ URL when passed to _send_request().
+    _STORE_ENDPOINT = SimpleNamespace(value="store")
+
+    def _send_envelope(self, envelope):
+        """Forward error events in the envelope to the legacy store endpoint."""
+        for item in envelope.items:
+            if item.type != "event":
+                continue
+            # Gzip the event and POST it as application/json, as sentry-sdk 1.x's
+            # HttpTransport._send_event did (the last version to speak /store/):
+            # https://github.com/getsentry/sentry-python/blob/282b8f7fae3da3c3ec26e5ee5e1599fc74661a72/sentry_sdk/transport.py#L376-L414
+            body = io.BytesIO()
+            with gzip.GzipFile(fileobj=body, mode="w") as fp:
+                fp.write(item.get_bytes())
+            self._send_request(
+                body.getvalue(),
+                headers={
+                    "Content-Type": "application/json",
+                    "Content-Encoding": "gzip",
+                },
+                endpoint_type=self._STORE_ENDPOINT,
+                envelope=envelope,
+            )

--- a/invenio_logging/sentry.py
+++ b/invenio_logging/sentry.py
@@ -118,9 +118,7 @@ class InvenioLoggingSentry(InvenioLoggingBase):
     def add_request_id_sentry_python(self, event, hint):
         """Add the request id as a tag."""
         if g and hasattr(g, "request_id"):
-            tags = event.get("tags") or []
-            tags.append(["request_id", g.request_id])
-            event["tags"] = tags
+            event.setdefault("tags", {})["request_id"] = g.request_id
         event_id = sentry_sdk.last_event_id()
         if event_id is not None:
             g.sentry_event_id = event_id

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -14,7 +14,7 @@ from flask import Flask
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.flask import FlaskIntegration
 
-from invenio_logging.sentry import InvenioLoggingSentry
+from invenio_logging.sentry import InvenioLoggingSentry, LegacyStoreTransport
 
 
 def test_init():
@@ -59,3 +59,54 @@ def test_sentry_failure():
         mock_send_request.assert_called()
 
     assert sentry_sdk.last_event_id() is not None
+
+
+def test_legacy_store_transport_hits_store_endpoint():
+    """LegacyStoreTransport sends events to the /store/ endpoint."""
+    app = Flask("testapp")
+    app.config["SENTRY_DSN"] = "http://user:pw@localhost/0"
+    app.config["LOGGING_SENTRY_INIT_KWARGS"] = {"transport": LegacyStoreTransport}
+    InvenioLoggingSentry(app)
+
+    transport = sentry_sdk.get_global_scope().client.transport
+    assert isinstance(transport, LegacyStoreTransport)
+
+    with patch.object(transport, "_send_request") as mock_send_request:
+        # An app context is needed because before_send writes g.sentry_event_id.
+        with app.app_context():
+            try:
+                1 / 0
+            except ZeroDivisionError:
+                app.logger.exception("boom")
+        time.sleep(2)
+        mock_send_request.assert_called()
+        endpoint = mock_send_request.call_args.kwargs["endpoint_type"]
+        # resolves to the legacy /store/ URL
+        assert getattr(endpoint, "value", endpoint) == "store"
+
+
+def test_default_transport_is_not_legacy_store():
+    """Without opting in, the standard envelope transport is used."""
+    app = Flask("testapp")
+    app.config["SENTRY_DSN"] = "http://user:pw@localhost/0"
+    InvenioLoggingSentry(app)
+
+    transport = sentry_sdk.get_global_scope().client.transport
+    assert not isinstance(transport, LegacyStoreTransport)
+
+
+def test_legacy_store_transport_drops_non_event_items():
+    """Only `event` items are forwarded; sessions/etc. are dropped."""
+    from sentry_sdk.envelope import Envelope
+
+    app = Flask("testapp")
+    app.config["SENTRY_DSN"] = "http://user:pw@localhost/0"
+    app.config["LOGGING_SENTRY_INIT_KWARGS"] = {"transport": LegacyStoreTransport}
+    InvenioLoggingSentry(app)
+
+    transport = sentry_sdk.get_global_scope().client.transport
+    env = Envelope()
+    env.add_session({"sid": "x", "status": "ok"})  # a non-event item
+    with patch.object(transport, "_send_request") as mock_send_request:
+        transport._send_envelope(env)
+        mock_send_request.assert_not_called()

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -6,11 +6,12 @@
 
 from __future__ import absolute_import, print_function
 
+import gzip
 import time
 from unittest.mock import patch
 
 import sentry_sdk
-from flask import Flask
+from flask import Flask, g
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.flask import FlaskIntegration
 
@@ -110,3 +111,31 @@ def test_legacy_store_transport_drops_non_event_items():
     with patch.object(transport, "_send_request") as mock_send_request:
         transport._send_envelope(env)
         mock_send_request.assert_not_called()
+
+
+def test_request_id_tag_delivered_with_existing_tags():
+    """Tagged events are delivered and get a request_id tag.
+
+    Regression: before_send appended to event["tags"], which sentry-sdk 2.x
+    represents as a dict once any tag is set. Appending to it raised inside
+    before_send, so the event was silently dropped.
+    """
+    app = Flask("testapp")
+    app.config["SENTRY_DSN"] = "http://user:pw@localhost/0"
+    InvenioLoggingSentry(app)
+
+    transport = sentry_sdk.get_global_scope().client.transport
+    with patch.object(transport, "_send_request") as mock_send_request:
+        with app.test_request_context("/"):
+            g.request_id = "req-123"
+            sentry_sdk.set_tag("existing", "value")  # makes event["tags"] a dict
+            try:
+                1 / 0
+            except ZeroDivisionError:
+                app.logger.exception("boom")
+        time.sleep(2)
+        # Delivered rather than dropped by before_send.
+        mock_send_request.assert_called()
+        payload = gzip.decompress(mock_send_request.call_args.args[0]).decode()
+        assert '"request_id":"req-123"' in payload
+        assert '"existing":"value"' in payload


### PR DESCRIPTION
> **AI disclosure:** Root cause and design came out of a Claude Code debugging session against our live Sentry 9.1.2 that I drove and reviewed; a second Claude Code session implemented it from that design, including the `request_id` in tags bug.

- **feat(sentry): LegacyStoreTransport for pre-envelope Sentry servers**
  * sentry-sdk 2.x only sends events via the envelope endpoint, which old
    self-hosted Sentry servers (e.g. Sentry 9.x, still run at CERN) reject, so
    their events are silently dropped. This transport routes events to the
    legacy /store/ endpoint those servers accept.
  * Staying on sentry-sdk 1.x is not an option: it is EOL and broken on
    Python 3.14.
  * Off by default; instances opt in via the existing LOGGING_SENTRY_INIT_KWARGS,
    so nothing changes for anyone on a modern Sentry.

- **fix(sentry): set request_id tag as dict, not list**
  * On sentry-sdk 2.x event["tags"] is a dict once any tag is set, so appending
    to it (as the old code did) raises inside before_send. sentry-sdk swallows
    that and silently drops the event, so any instance that sets a tag loses
    every error report.
  * Untagged events were unaffected, which is why it went unnoticed.
